### PR TITLE
Adding logger for backend services

### DIFF
--- a/Dockerfile-cs
+++ b/Dockerfile-cs
@@ -9,7 +9,7 @@ COPY ms/Configuration-tmplt.java ./
 RUN sed "s/<PASSWORD>/${MYSQL_PASSWORD}/g" < Configuration-tmplt.java > Configuration.java
 RUN rm Configuration-tmplt.java
 
-COPY ms/CreateServices.java ms/CreateServicesAI.java ./
+COPY ms/CreateServices.java ms/CreateServicesAI.java ms/ServerLogger.java ./
 RUN javac *.java
 
 CMD java CreateServices

--- a/Dockerfile-rs
+++ b/Dockerfile-rs
@@ -9,7 +9,7 @@ COPY ms/Configuration-tmplt.java ./
 RUN sed "s/<PASSWORD>/${MYSQL_PASSWORD}/g" < Configuration-tmplt.java > Configuration.java
 RUN rm Configuration-tmplt.java
 
-COPY  ms/RetrieveServices.java ms/RetrieveServicesAI.java ./
+COPY  ms/RetrieveServices.java ms/RetrieveServicesAI.java ms/ServerLogger.java ./
 RUN javac *.java
 
 CMD java RetrieveServices

--- a/ms/CreateServices.java
+++ b/ms/CreateServices.java
@@ -104,6 +104,8 @@ public class CreateServices extends UnicastRemoteObject implements CreateService
 
             stmt.executeUpdate(sql);
 
+            ServerLogger.info("Created new entry Successfully!");
+
             // clean up the environment
 
             stmt.close();
@@ -114,6 +116,7 @@ public class CreateServices extends UnicastRemoteObject implements CreateService
         } catch(Exception e) {
 
             ReturnString = e.toString();
+            ServerLogger.error("Failed to create new entry: " + ReturnString);
         } 
         
         return(ReturnString);

--- a/ms/RetrieveServices.java
+++ b/ms/RetrieveServices.java
@@ -129,6 +129,10 @@ public class RetrieveServices extends UnicastRemoteObject implements RetrieveSer
 
             ReturnString = ReturnString +"]";
 
+            System.out.println("Getting all orders: " + ReturnString);
+
+            ServerLogger.info("Retrieved Order Successfully: " + ReturnString);
+
             //Clean-up environment
 
             rs.close();
@@ -140,6 +144,7 @@ public class RetrieveServices extends UnicastRemoteObject implements RetrieveSer
         } catch(Exception e) {
 
             ReturnString = e.toString();
+            ServerLogger.error("Retrieving Orders Failed: " + ReturnString);
         } 
         
         return(ReturnString);
@@ -209,6 +214,8 @@ public class RetrieveServices extends UnicastRemoteObject implements RetrieveSer
 
             ReturnString = ReturnString +"]";
 
+            ServerLogger.info("Retrieved Order Successfully: " + ReturnString);
+
             //Clean-up environment
 
             rs.close();
@@ -220,9 +227,9 @@ public class RetrieveServices extends UnicastRemoteObject implements RetrieveSer
         } catch(Exception e) {
 
             ReturnString = e.toString();
-
+            ServerLogger.error("Retrieving Orders Failed: " + ReturnString);
         } 
-
+        System.out.println("Retrieve done");
         return(ReturnString);
 
     } //retrieve order by id

--- a/ms/ServerLogger.java
+++ b/ms/ServerLogger.java
@@ -1,0 +1,48 @@
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class ServerLogger {
+    private static final String LOG_FILE = "/usr/app/logs/server_application_logs.txt";
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private static void log(String level, String message) {
+        String timestamp = LocalDateTime.now().format(FORMATTER);
+        String logMessage = String.format("[%s] [%s] %s", timestamp, level, message);
+
+        File logFile = new File(LOG_FILE);
+
+        File parentDir = logFile.getParentFile();
+        if (parentDir != null && !parentDir.exists() && !parentDir.mkdirs()) {
+            System.err.println("Failed to create directory: " + parentDir.getAbsolutePath());
+            return;
+        }
+
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(logFile, true))) {
+            writer.write(logMessage);
+            writer.newLine();
+            writer.flush(); 
+        } catch (IOException e) {
+            System.err.println("Failed to write log: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    public static void info(String message) {
+        System.out.println("info............");
+        log("INFO", message);
+    }
+
+    public static void warn(String message) {
+        System.out.println("warn............");
+        log("WARNING", message);
+    }
+
+    public static void error(String message) {
+        System.out.println("error............");
+        log("ERROR", message);
+    }
+}

--- a/ms/ServerLogger.java
+++ b/ms/ServerLogger.java
@@ -4,31 +4,36 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class ServerLogger {
     private static final String LOG_FILE = "/usr/app/logs/server_application_logs.txt";
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final ExecutorService logExecutor = Executors.newSingleThreadExecutor();
 
     private static void log(String level, String message) {
         String timestamp = LocalDateTime.now().format(FORMATTER);
         String logMessage = String.format("[%s] [%s] %s", timestamp, level, message);
 
-        File logFile = new File(LOG_FILE);
+        logExecutor.submit(() -> {
+            File logFile = new File(LOG_FILE);
+            File parentDir = logFile.getParentFile();
+            if (parentDir != null && !parentDir.exists() && !parentDir.mkdirs()) {
+                System.err.println("Failed to create directory: " + parentDir.getAbsolutePath());
+                return;
+            }
 
-        File parentDir = logFile.getParentFile();
-        if (parentDir != null && !parentDir.exists() && !parentDir.mkdirs()) {
-            System.err.println("Failed to create directory: " + parentDir.getAbsolutePath());
-            return;
-        }
-
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(logFile, true))) {
-            writer.write(logMessage);
-            writer.newLine();
-            writer.flush(); 
-        } catch (IOException e) {
-            System.err.println("Failed to write log: " + e.getMessage());
-            e.printStackTrace();
-        }
+            try (BufferedWriter writer = new BufferedWriter(new FileWriter(logFile, true))) {
+                writer.write(logMessage);
+                writer.newLine();
+                writer.flush(); 
+            } catch (IOException e) {
+                System.err.println("Failed to write log: " + e.getMessage());
+                e.printStackTrace();
+            }
+        });
+        
     }
 
     public static void info(String message) {


### PR DESCRIPTION
### Overview
- Added a new functionality to store the application logs for server side activities
- Created `ServiceLogger.java` class to vend three functions:
  - info: To log `INFO` type logs
  - error: To log `ERROR` type logs
  - warn: To log `WARN` type logs
- Updated `RetrieveService` and `CreateService` to use logger to log the activities.
- Made corresponding dockerFile changes also.
### Testing
- The logs are visible in docker `ms_client` files -> `/use/app/logs/server_application_logs.txt`

![image](https://github.com/user-attachments/assets/89c4a496-f90f-452d-bc19-f31df3cae1e3)
![image](https://github.com/user-attachments/assets/f0394348-0e1f-4fca-ba68-a4ff72528a59)
